### PR TITLE
Arreglo de manejo de excepciones

### DIFF
--- a/lib/bloc/pet_bloc.dart
+++ b/lib/bloc/pet_bloc.dart
@@ -9,6 +9,7 @@ import 'package:mascotas/model/medical_visit.dart';
 import 'package:mascotas/model/pet.dart';
 import 'package:mascotas/model/treatment.dart';
 import 'package:mascotas/utils/format.dart';
+import 'package:mascotas/utils/tryCatchFormException.dart';
 
 class PetCubit extends Cubit<BlocState> {
   final PetsDatasource petsDatasource;
@@ -32,7 +33,7 @@ class PetCubit extends Cubit<BlocState> {
       required String address,
       required String date,
       required String observations}) async {
-    try {
+    await tryCatchFormException(() async {
       final medicalVisit = MedicalVisit(
           specialist: specialist,
           address: address,
@@ -41,18 +42,12 @@ class PetCubit extends Cubit<BlocState> {
       if (state is Loaded) {
         final Loaded currentState = state as Loaded;
         final Pet pet = currentState.value;
-        emit(Loading());
         final medicalVisitFromResponse =
             await petsDatasource.addMedicalVisit(medicalVisit, pet.id);
         pet.addMedicalVisit(medicalVisitFromResponse);
         emit(Loaded(value: pet));
       }
-    } on DatasourceException catch (error) {
-      emit(Error(message: error.message));
-    } catch (error) {
-      debugPrint(error.toString());
-      emit(Error(message: "Ocurrió un error inesperado"));
-    }
+    });
   }
 
   Future<void> startTreatment(
@@ -61,33 +56,27 @@ class PetCubit extends Cubit<BlocState> {
       required String dose,
       required String numberOfTime,
       required double frequency}) async {
-    final treatment = Treatment(
-      medicine: medicine,
-      startDate: formatStringToDateTime(startDate),
-      dose: dose,
-      numberOfTime: int.parse(numberOfTime),
-      frequency: frequency.round(),
-    );
-    try {
+    await tryCatchFormException(() async {
+      final treatment = Treatment(
+        medicine: medicine,
+        startDate: formatStringToDateTime(startDate),
+        dose: dose,
+        numberOfTime: int.parse(numberOfTime),
+        frequency: frequency.round(),
+      );
       if (state is Loaded) {
         final Loaded currentState = state as Loaded;
         final Pet pet = currentState.value;
-        emit(Loading());
         final treatmentFromResponse =
             await petsDatasource.startTreatment(treatment, pet.id);
         pet.startTreatment(treatmentFromResponse);
         emit(Loaded(value: pet));
       }
-    } on DatasourceException catch (error) {
-      emit(Error(message: error.message));
-    } catch (error) {
-      debugPrint(error.toString());
-      emit(Error(message: "Ocurrió un error inesperado"));
-    }
+    });
   }
 
   void uploadAnalysis(File file) async {
-    try {
+    await tryCatchFormException(() async {
       if (state is Loaded) {
         final Loaded currentState = state as Loaded;
         final Pet pet = currentState.value;
@@ -95,11 +84,6 @@ class PetCubit extends Cubit<BlocState> {
         await petsDatasource.uploadAnalysis(file, pet.id);
         emit(Loaded(value: pet));
       }
-    } on DatasourceException catch (error) {
-      emit(Error(message: error.message));
-    } catch (error) {
-      debugPrint(error.toString());
-      emit(Error(message: "Ocurrió un error inesperado"));
-    }
+    });
   }
 }

--- a/lib/bloc/pet_bloc.dart
+++ b/lib/bloc/pet_bloc.dart
@@ -75,12 +75,11 @@ class PetCubit extends Cubit<BlocState> {
     });
   }
 
-  void uploadAnalysis(File file) async {
+  Future<void> uploadAnalysis(File file) async {
     await tryCatchFormException(() async {
       if (state is Loaded) {
         final Loaded currentState = state as Loaded;
         final Pet pet = currentState.value;
-        emit(Loading());
         await petsDatasource.uploadAnalysis(file, pet.id);
         emit(Loaded(value: pet));
       }

--- a/lib/bloc/pets_bloc.dart
+++ b/lib/bloc/pets_bloc.dart
@@ -7,6 +7,7 @@ import 'package:mascotas/datasource/pets_datasource.dart';
 import 'package:mascotas/exception/datasource_exception.dart';
 import 'package:mascotas/model/pet.dart';
 import 'package:mascotas/utils/format.dart';
+import 'package:mascotas/utils/tryCatchFormException.dart';
 
 class PetsCubit extends Cubit<BlocState> {
   final PetsDatasource petsDatasource;
@@ -37,7 +38,7 @@ class PetsCubit extends Cubit<BlocState> {
       required String breed,
       required String fur,
       required String sex}) async {
-    try {
+    await tryCatchFormException(() async {
       if (state is Loaded) {
         final Loaded currentState = state as Loaded;
         final List<Pet> pets = currentState.value;
@@ -64,11 +65,6 @@ class PetsCubit extends Cubit<BlocState> {
         pets.add(petResponse);
         emit(Loaded(value: pets));
       }
-    } on DatasourceException catch (error) {
-      emit(Error(message: error.message));
-    } catch (error) {
-      debugPrint(error.toString());
-      emit(Error(message: "Ocurrió un error inesperado"));
-    }
+    });
   }
 }

--- a/lib/datasource/pets_datasource.dart
+++ b/lib/datasource/pets_datasource.dart
@@ -101,7 +101,7 @@ class PetsDatasource {
     }
     if (_isClientError(response)) {
       throw DatasourceException(
-        json['message'] ?? json['messages'].toString(),
+        json['message'] ?? json['messages'].first,
       );
     } else {
       throw DatasourceException(message);

--- a/lib/utils/tryCatchFormException.dart
+++ b/lib/utils/tryCatchFormException.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:mascotas/exception/datasource_exception.dart';
+
+Future<void> tryCatchFormException(Future<void> Function() changeState) async {
+  try {
+    return await changeState();
+  } on DatasourceException catch (_) {
+    rethrow;
+  } catch (error) {
+    debugPrint(error.toString());
+    throw DatasourceException("Ocurrió un error inesperado");
+  }
+}

--- a/lib/utils/tryCatchFormException.dart
+++ b/lib/utils/tryCatchFormException.dart
@@ -3,7 +3,7 @@ import 'package:mascotas/exception/datasource_exception.dart';
 
 Future<void> tryCatchFormException(Future<void> Function() changeState) async {
   try {
-    return await changeState();
+    await changeState();
   } on DatasourceException catch (_) {
     rethrow;
   } catch (error) {

--- a/lib/utils/validator.dart
+++ b/lib/utils/validator.dart
@@ -4,3 +4,10 @@ String? emptyFieldValidator(String? text) {
   }
   return null;
 }
+
+String? numberGreaterThanZero(String? text) {
+  if (text != null && int.parse(text) <= 0) {
+    return "El numero ingresado debe ser mayor a cero";
+  }
+  return emptyFieldValidator(text);
+}

--- a/lib/widget/avatar.dart
+++ b/lib/widget/avatar.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/widget/medical_visit_registration_form.dart
+++ b/lib/widget/medical_visit_registration_form.dart
@@ -20,6 +20,7 @@ class _MedicalVisitRegistrationFormState
   final _addressController = TextEditingController();
   final _observationsController = TextEditingController();
   final _dateController = TextEditingController();
+  bool _isLoading = false;
 
   @override
   Widget build(BuildContext context) {
@@ -69,10 +70,12 @@ class _MedicalVisitRegistrationFormState
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: ElevatedButton(
                       onPressed: saveMedicalVisit,
-                      child: const Text(
-                        "Registrar",
-                        style: TextStyle(color: Colors.white),
-                      )),
+                      child: _isLoading
+                          ? const CircularProgressIndicator()
+                          : const Text(
+                              "Registrar",
+                              style: TextStyle(color: Colors.white),
+                            )),
                 )
               ],
             ),
@@ -98,6 +101,9 @@ class _MedicalVisitRegistrationFormState
 
   void saveMedicalVisit() {
     if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isLoading = true;
+      });
       context
           .read<PetCubit>()
           .addMedicalVisit(
@@ -115,8 +121,14 @@ class _MedicalVisitRegistrationFormState
       }).catchError((error) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('No se pudo agregar la visita médica: ${error.message}')),
+          SnackBar(
+              content: Text(
+                  'No se pudo agregar la visita médica: ${error.message}')),
         );
+      }).whenComplete(() {
+        setState(() {
+          _isLoading = false;
+        });
       });
     }
   }

--- a/lib/widget/medical_visit_registration_form.dart
+++ b/lib/widget/medical_visit_registration_form.dart
@@ -98,24 +98,26 @@ class _MedicalVisitRegistrationFormState
 
   void saveMedicalVisit() {
     if (_formKey.currentState!.validate()) {
-      try {
-        context.read<PetCubit>().addMedicalVisit(
-              specialist: _specialistController.text,
-              address: _addressController.text,
-              date: _dateController.text,
-              observations: _observationsController.text,
-            );
+      context
+          .read<PetCubit>()
+          .addMedicalVisit(
+            specialist: _specialistController.text,
+            address: _addressController.text,
+            date: _dateController.text,
+            observations: _observationsController.text,
+          )
+          .then((_) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
               content: Text("Se agregó la visita médica de forma exitosa")),
         );
-      } catch (error) {
+      }).catchError((error) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(error.toString())),
+          SnackBar(content: Text('No se pudo agregar la visita médica: ${error.message}')),
         );
-      }
+      });
     }
   }
 }

--- a/lib/widget/pet_detail.dart
+++ b/lib/widget/pet_detail.dart
@@ -1,10 +1,6 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:mascotas/model/medical_visit.dart';
 import 'package:mascotas/model/pet.dart';
-import 'package:mascotas/utils/format.dart';
 import 'package:mascotas/widget/pet_tab_controller.dart';
-import 'package:mascotas/widget/pets_divider.dart';
 import 'avatar.dart';
 
 class PetDetail extends StatelessWidget {

--- a/lib/widget/pet_registration_form.dart
+++ b/lib/widget/pet_registration_form.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:image_picker/image_picker.dart';
@@ -78,7 +76,8 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
                     setState(() {
                       _weight = value;
                     });
-                  }, text: '${_weight.round()} kg',
+                  },
+                  text: '${_weight.round()} kg',
                 ),
                 TextFormFieldWithTitle(
                   nameController: _birthdateController,
@@ -150,23 +149,29 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
 
   void savePet() {
     if (_formKey.currentState!.validate()) {
-      try {
-        context.read<PetsCubit>().addPet(
-              name: _nameController.text,
-              photo: _photo,
-              weight: _weight,
-              birthdate: _birthdateController.text,
-              breed: _breedController.text,
-              fur: _furController.text,
-              sex: _sex.name.toUpperCase(),
-            );
-        Navigator.pop(context);
-      } catch (error) {
+      context
+          .read<PetsCubit>()
+          .addPet(
+            name: _nameController.text,
+            photo: _photo,
+            weight: _weight,
+            birthdate: _birthdateController.text,
+            breed: _breedController.text,
+            fur: _furController.text,
+            sex: _sex.name.toUpperCase(),
+          )
+          .then((_) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(error.toString())),
+          const SnackBar(
+              content: Text("Se registro la mascota de forma exitosa")),
         );
-      }
+      }).catchError((error) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('No se pudo registrar la mascota: ${error.message}')),
+        );
+      });
     }
   }
 

--- a/lib/widget/pet_registration_form.dart
+++ b/lib/widget/pet_registration_form.dart
@@ -27,6 +27,7 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
   double _weight = 8;
   PetSex _sex = PetSex.female;
   String _photo = "";
+  bool _isLoading = false;
 
   @override
   Widget build(BuildContext context) {
@@ -107,10 +108,12 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: ElevatedButton(
                       onPressed: savePet,
-                      child: const Text(
-                        "Registrar",
-                        style: TextStyle(color: Colors.white),
-                      )),
+                      child: _isLoading
+                          ? const CircularProgressIndicator()
+                          : const Text(
+                              "Registrar",
+                              style: TextStyle(color: Colors.white),
+                            )),
                 )
               ],
             ),
@@ -149,6 +152,9 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
 
   void savePet() {
     if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isLoading = true;
+      });
       context
           .read<PetsCubit>()
           .addPet(
@@ -169,8 +175,14 @@ class _PetRegistrationFormState extends State<PetRegistrationForm> {
       }).catchError((error) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('No se pudo registrar la mascota: ${error.message}')),
+          SnackBar(
+              content:
+                  Text('No se pudo registrar la mascota: ${error.message}')),
         );
+      }).whenComplete(() {
+        setState(() {
+          _isLoading = false;
+        });
       });
     }
   }

--- a/lib/widget/pet_tab_controller.dart
+++ b/lib/widget/pet_tab_controller.dart
@@ -106,11 +106,19 @@ class _PetTabControllerState extends State<PetTabController> {
   }
 
   void uploadPDF() {
-    FilePicker.platform.pickFiles().then((result) {
+    FilePicker.platform.pickFiles().then((result) async {
       if (result != null) {
         File file = File(result.files.single.path!);
-        context.read<PetCubit>().uploadAnalysis(file);
+        await context.read<PetCubit>().uploadAnalysis(file);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Se cargo el análisis exitosamente')),
+        );
       }
+    }).catchError((error) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text('No se pudo cargar el análisis: ${error.message}')),
+      );
     });
   }
 }

--- a/lib/widget/text_form_field_with_title.dart
+++ b/lib/widget/text_form_field_with_title.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:http/http.dart';
 import 'input_title.dart';
 
 class TextFormFieldWithTitle extends StatelessWidget {

--- a/lib/widget/treatment_form.dart
+++ b/lib/widget/treatment_form.dart
@@ -17,7 +17,8 @@ class _TreatmentFormState extends State<TreatmentForm> {
   final TextEditingController _medicineController = TextEditingController();
   final TextEditingController _dateController = TextEditingController();
   final TextEditingController _doseController = TextEditingController();
-  final TextEditingController _numerOfTimesController = TextEditingController();
+  final TextEditingController _numberOfTimesController =
+      TextEditingController();
   double _frequency = 1;
   final _formKey = GlobalKey<FormState>();
 
@@ -25,7 +26,7 @@ class _TreatmentFormState extends State<TreatmentForm> {
   Widget build(BuildContext context) {
     return Padding(
       padding:
-      EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
       child: SingleChildScrollView(
         child: Form(
           key: _formKey,
@@ -62,8 +63,8 @@ class _TreatmentFormState extends State<TreatmentForm> {
                   title: "Cantidad",
                 ),
                 TextFormField(
-                  controller: _numerOfTimesController,
-                  validator: emptyFieldValidator,
+                  controller: _numberOfTimesController,
+                  validator: numberGreaterThanZero,
                   keyboardType: TextInputType.number,
                 ),
                 const InputTitle(
@@ -78,7 +79,8 @@ class _TreatmentFormState extends State<TreatmentForm> {
                     setState(() {
                       _frequency = value;
                     });
-                  }, text: '${_frequency.round()} hr',
+                  },
+                  text: '${_frequency.round()} hr',
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -97,27 +99,29 @@ class _TreatmentFormState extends State<TreatmentForm> {
     );
   }
 
-  void startTreatment() {
+  Future<void> startTreatment() async {
     if (_formKey.currentState!.validate()) {
-      try {
-        context.read<PetCubit>().startTreatment(
-          medicine: _medicineController.text,
-          startDate: _dateController.text,
-          dose: _doseController.text,
-          numberOfTime: _numerOfTimesController.text,
-          frequency: _frequency,
-        );
+      context
+          .read<PetCubit>()
+          .startTreatment(
+            medicine: _medicineController.text,
+            startDate: _dateController.text,
+            dose: _doseController.text,
+            numberOfTime: _numberOfTimesController.text,
+            frequency: _frequency,
+          )
+          .then((_) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
               content: Text("Se inició el tratamiento de forma exitosa")),
         );
-      } catch (error) {
+      }).catchError((error) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(error.toString())),
+          SnackBar(content: Text('No se pudo iniciar el tratamiento: ${error.message}')),
         );
-      }
+      });
     }
   }
 
@@ -134,5 +138,4 @@ class _TreatmentFormState extends State<TreatmentForm> {
       _dateController.text = formatDateToString(picked);
     }
   }
-
 }

--- a/lib/widget/treatment_form.dart
+++ b/lib/widget/treatment_form.dart
@@ -21,6 +21,7 @@ class _TreatmentFormState extends State<TreatmentForm> {
       TextEditingController();
   double _frequency = 1;
   final _formKey = GlobalKey<FormState>();
+  bool _isLoading = false;
 
   @override
   Widget build(BuildContext context) {
@@ -86,10 +87,12 @@ class _TreatmentFormState extends State<TreatmentForm> {
                   padding: const EdgeInsets.symmetric(vertical: 8.0),
                   child: ElevatedButton(
                       onPressed: startTreatment,
-                      child: const Text(
-                        "Guardar",
-                        style: TextStyle(color: Colors.white),
-                      )),
+                      child: _isLoading
+                          ? const CircularProgressIndicator()
+                          : const Text(
+                              "Guardar",
+                              style: TextStyle(color: Colors.white),
+                            )),
                 )
               ],
             ),
@@ -101,6 +104,9 @@ class _TreatmentFormState extends State<TreatmentForm> {
 
   Future<void> startTreatment() async {
     if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isLoading = true;
+      });
       context
           .read<PetCubit>()
           .startTreatment(
@@ -119,8 +125,14 @@ class _TreatmentFormState extends State<TreatmentForm> {
       }).catchError((error) {
         Navigator.pop(context);
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('No se pudo iniciar el tratamiento: ${error.message}')),
+          SnackBar(
+              content:
+                  Text('No se pudo iniciar el tratamiento: ${error.message}')),
         );
+      }).whenComplete(() {
+        setState(() {
+          _isLoading = false;
+        });
       });
     }
   }

--- a/test/bloc/pet_bloc_test.dart
+++ b/test/bloc/pet_bloc_test.dart
@@ -6,6 +6,7 @@ import 'package:http/http.dart';
 import 'package:mascotas/bloc/bloc_state.dart';
 import 'package:mascotas/bloc/pet_bloc.dart';
 import 'package:mascotas/datasource/pets_datasource.dart';
+import 'package:mascotas/exception/datasource_exception.dart';
 import 'package:mascotas/model/pet.dart';
 import 'package:mascotas/utils/format.dart';
 import 'package:mockito/mockito.dart';
@@ -78,13 +79,11 @@ void main() {
     },
     expect: () => [
       Loaded(value: petWithMedicalVisits),
-      Loading(),
-      Loaded(value: petWithMedicalVisits),
     ],
   );
 
   blocTest(
-    "Al registrar una visita médica en una mascota con el id dado algo sale mal y obtengo un error",
+    "Al registrar una visita médica en una mascota con el id dado algo sale mal y no se actualiza la mascota",
     setUp: () {
       when(
         mockApi.get(
@@ -106,10 +105,9 @@ void main() {
           date: formatDateToString(medicalVisit.date),
           observations: medicalVisit.observations);
     },
+    errors: () => [isA<DatasourceException>()],
     expect: () => [
       Loaded(value: pet),
-      Loading(),
-      Error(message: "Ocurrió un error inesperado"),
     ],
   );
 
@@ -139,13 +137,11 @@ void main() {
     },
     expect: () => [
       Loaded(value: petWithTreatment),
-      Loading(),
-      Loaded(value: petWithTreatment),
     ],
   );
 
   blocTest(
-    "Al iniciar un tramamiento para una mascota con el id dado algo sale mal y obtengo un error",
+    "Al iniciar un tramamiento para una mascota con el id dado algo sale mal y no se actualiza la mascota",
     setUp: () {
       when(
         mockApi.get(
@@ -169,10 +165,9 @@ void main() {
         frequency: treatment.frequency.toDouble(),
       );
     },
+    errors: () => [isA<DatasourceException>()],
     expect: () => [
       Loaded(value: pet),
-      Loading(),
-      Error(message: "Ocurrió un error inesperado"),
     ],
   );
 }


### PR DESCRIPTION
- Cambio de manejo de excepciones para que el Cubit no muestre un estado de error sino que deje continuar la excepcion para que lo atrape en el formulario y muestre un mensaje de error sin cambiar la pantalla
- El estado de loading ahora se muestra en el boton del formulario 