### PR TITLE
fix hora de inicio de tratamiento

### DIFF
--- a/lib/utils/format.dart
+++ b/lib/utils/format.dart
@@ -27,7 +27,7 @@ DateTime parseDateStringAsDateTime(String date) {
 }
 
 DateTime parseTimeStringAsDateTime(String timeOfDay) {
-  final format = DateFormat("HH:mm a");
+  final format = DateFormat("h:mm a");
   final selectedTime = format.parse(timeOfDay);
   final now = DateTime.now();
   final selectedDate = DateTime(


### PR DESCRIPTION
Con el otro formato cuando eran las 12 el timeOfDay era "12:00 AM" o "12:00 PM" y cuando hacia el parseo le agregaba 12 horas lo que hacia que AM pasara a PM y PM a AM